### PR TITLE
Fix React 19 peer dependency conflicts in Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,8 +52,8 @@ pipeline {
         stage('Install Dependencies') {
             steps {
                 sh '''
-                    # Clean install to ensure fresh dependencies
-                    npm ci
+                    # Clean install to ensure fresh dependencies (with legacy peer deps for React 19 compatibility)
+                    npm ci --legacy-peer-deps
 
                     # Install React Native CLI if not present
                     npm install -g @react-native-community/cli || true


### PR DESCRIPTION
- Add --legacy-peer-deps flag to npm ci command
- Resolves React 19.0.0 vs testing library React 18.x compatibility issues
- Enables Jenkins builds to proceed without dependency resolution errors

🤖 Generated with Claude Code (https://claude.ai/code)