### PR TITLE
Fix gradlew permission denied error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,6 +144,9 @@ EOF
                         sh '''
                             cd android
 
+                            # Make gradlew executable (fix permission denied error)
+                            chmod +x gradlew
+
                             # Clean previous builds
                             ./gradlew clean
 


### PR DESCRIPTION
- Add chmod +x gradlew before running Gradle commands in Android build stage
- Fixes Jenkins CI/CD pipeline issue where gradlew script lacks execute permissions
- Enables successful Android APK builds in Jenkins environment

🤖 Generated with [Claude Code](https://claude.ai/code)