### PR TITLE
Standardize Jenkins email notification address

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -319,7 +319,7 @@ EOF
             emailext (
                 subject: "FAILED: React Native Store Build - ${APP_NAME}",
                 body: "React Native store-ready build failed for ${APP_NAME}. Check Jenkins for details.",
-                to: "dylan@kesslersoftware.com"
+                to: "contact+jenkins@kesslersoftware.com"
             )
         }
     }


### PR DESCRIPTION
- Change failure notification email from dylan@kesslersoftware.com to contact+jenkins@kesslersoftware.com
- Ensures consistent email routing for all Jenkins build notifications
- Matches standardization applied across all Lambda repositories

🤖 Generated with [Claude Code](https://claude.ai/code)